### PR TITLE
Closes #5 - Temporary fix to increase limit of jobs recalculated.

### DIFF
--- a/CRM/RecalculateRecipients/Run.php
+++ b/CRM/RecalculateRecipients/Run.php
@@ -3,7 +3,13 @@ class CRM_RecalculateRecipients_Run{
   static function run(){
 
     $currentTime = date('YmdHis');
-    $jobs = civicrm_api3('MailingJob', 'get', ['status' =>  'scheduled', 'scheduled_date' => ['<=' => $currentTime]]);
+    $jobs = civicrm_api3('MailingJob', 'get',
+      [
+        'status' =>  'scheduled',
+        'scheduled_date' => ['<=' => $currentTime],
+        'options' => ['limit' => 100],
+      ]
+    );
     foreach($jobs['values'] as $job){
       $mailings[] = $job['mailing_id'];
     }


### PR DESCRIPTION
Temporary fix to increase limit of jobs recalculated. 100 should be enough for almost any site. In my current case we will clean up our data to get rid of the 50 or so stalled jobs but that will take some investigation.