### PR TITLE
civix upgrade

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -22,6 +22,10 @@
   </compatibility>
   <civix>
     <namespace>CRM/RecalculateRecipients</namespace>
-    <format>22.05.2</format>
+    <format>23.02.1</format>
   </civix>
+  <classloader>
+    <psr0 prefix="CRM_" path="."/>
+    <psr4 prefix="Civi\" path="Civi"/>
+  </classloader>
 </extension>

--- a/recalculate_recipients.civix.php
+++ b/recalculate_recipients.civix.php
@@ -24,7 +24,7 @@ class CRM_RecalculateRecipients_ExtensionUtil {
    *   Translated text.
    * @see ts
    */
-  public static function ts($text, $params = []) {
+  public static function ts($text, $params = []): string {
     if (!array_key_exists('domain', $params)) {
       $params['domain'] = [self::LONG_NAME, NULL];
     }
@@ -41,7 +41,7 @@ class CRM_RecalculateRecipients_ExtensionUtil {
    *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
    *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
    */
-  public static function url($file = NULL) {
+  public static function url($file = NULL): string {
     if ($file === NULL) {
       return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
     }
@@ -91,25 +91,14 @@ function _recalculate_recipients_civix_mixin_polyfill() {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
  */
-function _recalculate_recipients_civix_civicrm_config(&$config = NULL) {
+function _recalculate_recipients_civix_civicrm_config($config = NULL) {
   static $configured = FALSE;
   if ($configured) {
     return;
   }
   $configured = TRUE;
 
-  $template = CRM_Core_Smarty::singleton();
-
   $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
-  $extDir = $extRoot . 'templates';
-
-  if (is_array($template->template_dir)) {
-    array_unshift($template->template_dir, $extDir);
-  }
-  else {
-    $template->template_dir = [$extDir, $template->template_dir];
-  }
-
   $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
   set_include_path($include_path);
   _recalculate_recipients_civix_mixin_polyfill();
@@ -122,36 +111,7 @@ function _recalculate_recipients_civix_civicrm_config(&$config = NULL) {
  */
 function _recalculate_recipients_civix_civicrm_install() {
   _recalculate_recipients_civix_civicrm_config();
-  if ($upgrader = _recalculate_recipients_civix_upgrader()) {
-    $upgrader->onInstall();
-  }
   _recalculate_recipients_civix_mixin_polyfill();
-}
-
-/**
- * Implements hook_civicrm_postInstall().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
- */
-function _recalculate_recipients_civix_civicrm_postInstall() {
-  _recalculate_recipients_civix_civicrm_config();
-  if ($upgrader = _recalculate_recipients_civix_upgrader()) {
-    if (is_callable([$upgrader, 'onPostInstall'])) {
-      $upgrader->onPostInstall();
-    }
-  }
-}
-
-/**
- * Implements hook_civicrm_uninstall().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
- */
-function _recalculate_recipients_civix_civicrm_uninstall() {
-  _recalculate_recipients_civix_civicrm_config();
-  if ($upgrader = _recalculate_recipients_civix_upgrader()) {
-    $upgrader->onUninstall();
-  }
 }
 
 /**
@@ -159,59 +119,9 @@ function _recalculate_recipients_civix_civicrm_uninstall() {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
  */
-function _recalculate_recipients_civix_civicrm_enable() {
+function _recalculate_recipients_civix_civicrm_enable(): void {
   _recalculate_recipients_civix_civicrm_config();
-  if ($upgrader = _recalculate_recipients_civix_upgrader()) {
-    if (is_callable([$upgrader, 'onEnable'])) {
-      $upgrader->onEnable();
-    }
-  }
   _recalculate_recipients_civix_mixin_polyfill();
-}
-
-/**
- * (Delegated) Implements hook_civicrm_disable().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
- * @return mixed
- */
-function _recalculate_recipients_civix_civicrm_disable() {
-  _recalculate_recipients_civix_civicrm_config();
-  if ($upgrader = _recalculate_recipients_civix_upgrader()) {
-    if (is_callable([$upgrader, 'onDisable'])) {
-      $upgrader->onDisable();
-    }
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_upgrade().
- *
- * @param $op string, the type of operation being performed; 'check' or 'enqueue'
- * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
- *
- * @return mixed
- *   based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
- *   for 'enqueue', returns void
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
- */
-function _recalculate_recipients_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
-  if ($upgrader = _recalculate_recipients_civix_upgrader()) {
-    return $upgrader->onUpgrade($op, $queue);
-  }
-}
-
-/**
- * @return CRM_RecalculateRecipients_Upgrader
- */
-function _recalculate_recipients_civix_upgrader() {
-  if (!file_exists(__DIR__ . '/CRM/RecalculateRecipients/Upgrader.php')) {
-    return NULL;
-  }
-  else {
-    return CRM_RecalculateRecipients_Upgrader_Base::instance();
-  }
 }
 
 /**
@@ -230,8 +140,8 @@ function _recalculate_recipients_civix_insert_navigation_menu(&$menu, $path, $it
   if (empty($path)) {
     $menu[] = [
       'attributes' => array_merge([
-        'label'      => CRM_Utils_Array::value('name', $item),
-        'active'     => 1,
+        'label' => $item['name'] ?? NULL,
+        'active' => 1,
       ], $item),
     ];
     return TRUE;
@@ -294,15 +204,4 @@ function _recalculate_recipients_civix_fixNavigationMenuItems(&$nodes, &$maxNavI
       _recalculate_recipients_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
     }
   }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_entityTypes().
- *
- * Find any *.entityType.php files, merge their content, and return.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
- */
-function _recalculate_recipients_civix_civicrm_entityTypes(&$entityTypes) {
-  $entityTypes = array_merge($entityTypes, []);
 }

--- a/recalculate_recipients.php
+++ b/recalculate_recipients.php
@@ -22,24 +22,6 @@ function recalculate_recipients_civicrm_install() {
 }
 
 /**
- * Implements hook_civicrm_postInstall().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
- */
-function recalculate_recipients_civicrm_postInstall() {
-  _recalculate_recipients_civix_civicrm_postInstall();
-}
-
-/**
- * Implements hook_civicrm_uninstall().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
- */
-function recalculate_recipients_civicrm_uninstall() {
-  _recalculate_recipients_civix_civicrm_uninstall();
-}
-
-/**
  * Implements hook_civicrm_enable().
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_enable
@@ -48,37 +30,10 @@ function recalculate_recipients_civicrm_enable() {
   _recalculate_recipients_civix_civicrm_enable();
 }
 
-/**
- * Implements hook_civicrm_disable().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable
- */
-function recalculate_recipients_civicrm_disable() {
-  _recalculate_recipients_civix_civicrm_disable();
-}
-
-/**
- * Implements hook_civicrm_upgrade().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_upgrade
- */
-function recalculate_recipients_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
-  return _recalculate_recipients_civix_civicrm_upgrade($op, $queue);
-}
-
 function recalculate_recipients_civicrm_apiWrappers(&$wrappers, $apiRequest) {
   //&apiWrappers is an array of wrappers, you can add your(s) with the hook.
   // You can use the apiRequest to decide if you want to add the wrapper (eg. only wrap api.Contact.create)
   if ($apiRequest['entity'] == 'Job' && $apiRequest['action'] == 'process_mailing') {
     $wrappers[] = new CRM_RecalculateRecipients_Wrapper();
   }
-}
-
-/**
- * Implements hook_civicrm_entityTypes().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
- */
-function recalculate_recipients_civicrm_entityTypes(&$entityTypes) {
-  _recalculate_recipients_civix_civicrm_entityTypes($entityTypes);
 }


### PR DESCRIPTION
This avoids error:

> [PHP Notice] Indirect modification of overloaded property CRM_Core_Smarty::$template_dir has no effect

When running with PHP 8.3 and Smarty4.